### PR TITLE
test scip integration from python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -265,6 +265,8 @@ outputs:
         - pip check
         - ${PYTHON} cmake/samples/python/sample.py
         - ${PYTHON} ortools/sat/samples/assignment_sat.py
+        # check that scip is loadable
+        - python -c "from ortools.linear_solver import pywraplp; pywraplp.Solver.CreateSolver('SCIP')"  # [not (aarch64 or ppc64le)]
       requires:
         - pip
       source_files:


### PR DESCRIPTION
Follow-up to #36.

There I got a tip how to test scip from the C++ side, but looking at https://github.com/google/or-tools/issues/3752 again, I noticed that we should be able to test something also from the python side (which would have obviated the need for the `ortools-samples` output, but oh well...).

Let's see if this works. 🤞 